### PR TITLE
Handle Custom Errors Created Without Info

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ class ErrorTypeError extends Error {
   constructor ({ message, info }) {
     super(message)
     this.name = this.constructor.name
-    this.info = info
+    if (info) {
+      this.info = info
+    }
   }
 
   /**

--- a/test/error-type-class.test.js
+++ b/test/error-type-class.test.js
@@ -95,6 +95,17 @@ describe('errorType.Error', () => {
       )
     }
   })
+
+  it('handles a custom error without info', () => {
+    try {
+      throw new CustomError1({})
+      expect.fail('should have thrown')
+    } catch (e) {
+      expect(errorType.getFullInfo(e)).to.deep.equal({})
+      let infoKey = Object.keys(e).find(k => k === 'info')
+      expect(infoKey).to.not.exist
+    }
+  })
 })
 
 describe('errorType.ErrorWithStatusCode', () => {


### PR DESCRIPTION
Creating a new `ErrorTypeError` without the `info` option still adds the (undefined) attribute to the error and it gets printed with the error. This is not necessary.

Before:
```
{ CustomError1: failed to foo
    at ...
    at processImmediate (timers.js:649:5) name: 'CustomError1', info: undefined }
```

After:
```
{ CustomError1: failed to foo
    at ...
    at processImmediate (timers.js:649:5) name: 'CustomError1' }
```

Note that this changes also affects `info` passed but with `null`, `0` or `""` values. I think that's fine.
